### PR TITLE
Update dependency-management-plugin version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ theSourceCompatibility=1.8
 theSpringBootVersion=1.3.3.RELEASE
 theSpringCloudVersion=Brixton.RC1
 theSpringPlatformBomVersion=2.0.3.RELEASE
-theDependencyManagementPlugin=0.5.2.RELEASE
+theDependencyManagementPlugin=0.6.1.RELEASE


### PR DESCRIPTION
Current version fails to build due to an issue with dependency-management-plugin.

Gradle release 3.0 removed StyledTextOutput. dependency-management-plugin was updated to no longer use this.

https://github.com/spring-gradle-plugins/dependency-management-plugin/commit/60e325b4face8e6ea62945892f9d6c5c6172e3ef